### PR TITLE
Build docker faster test

### DIFF
--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -1,0 +1,23 @@
+# This file modified from: 
+# https://discourse.jupyter.org/t/how-to-reduce-mybinder-org-repository-startup-time/4956/2
+# https://github.com/laderast/RBootcamp/blob/master/.github/workflows/build_container.yml
+
+name: Build Container
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: update jupyter dependencies with repo2docker
+      uses: jupyterhub/repo2docker-action@master
+      with:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        BINDER_CACHE: true
+        PUBLIC_REGISTRY_CHECK: true


### PR DESCRIPTION
Currently takes several minutes to build the Docker container for the Raise the Bar website. We want to optimize the build time. This PR tests to see if pre-building Docker Container with GitHub Actions decreases Binder launch time. The Dockerfile should be automatically updated upon successfull push to /binder. 